### PR TITLE
fix(package.json): move q to dependancies since it is required to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "q": "~0.9.7"
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt": "~0.4.1",
-    "q": "~0.9.7",
     "exec": "0.0.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
While trying to run git_changelog after a `npm install git-changelog --save-dev`, I
found I was missing q, which is not installed when added to a project
this way.
