### PR TITLE
fix(git_changelog_generate): pass tag if it exists to gitReadLog

### DIFF
--- a/tasks/git_changelog_generate.js
+++ b/tasks/git_changelog_generate.js
@@ -249,7 +249,7 @@ var generate = function(params) {
 
         if(typeof(tag) !== 'undefined'){
             console.log('Reading git log since', tag);
-            fn = function(){ return readGitLog(GIT_LOG_CMD);};
+            fn = function(){ return readGitLog(GIT_LOG_CMD, tag);};
         }else{
             console.log('Reading git log since the beggining');
             fn = function(){ return readGitLog(GIT_NOTAG_LOG_CMD);};


### PR DESCRIPTION
Previously if a tag was found the script would try to find commits
between undefined..HEAD. By passing the tag, it now finds tags between
tag..HEAD.

Closes #5.
