### PR TITLE
fix: correctly detect when running under grunt on Windows

### DIFF
--- a/tasks/command.js
+++ b/tasks/command.js
@@ -9,7 +9,7 @@ var _ = require('lodash');
 var options = _.defaults({}, defaults);
 
 
-if (process.argv.join('').indexOf('/grunt') === -1) {
+if (process.argv.join('').replace(/\\/g,'/').indexOf('/grunt') === -1) {
 
   program
     .version('0.1.7')


### PR DESCRIPTION
This fixes an issue I was encountering while running git-changelog  on Windows in PowerShell, as opposed to cygwin. Seems as though the method for detecting whether the program is running under grunt wasn't working because the argv path contained backslashes rather than forward slashes.

Without this, the command line version of git-changelog is run as soon as the npm task is registered, rather than waiting for grunt to initiate it via a task.

The fix works by replacing backslashes with forward slashes before checking for the presence of `'/grunt'`.