### PR TITLE
Cli url fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "istanbul": "^0.3.13",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1",
-    "sinon-chai": "^2.7.0"
+    "sinon-chai": "^2.7.0",
+    "concat-stream": "^1.5.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/command.js
+++ b/tasks/command.js
@@ -55,9 +55,9 @@ if (process.argv.join('').indexOf('/grunt') === -1) {
     options.intro = program.intro;
   }
 
-  if (program.url){
-    options.repo_url = program.url;
-    console.log('  - With URL %s', program.url);
+  if (program.repo_url){
+    options.repo_url = program.repo_url;
+    console.log('  - With URL %s', program.repo_url);
   }
 
   if (program.tag !== undefined){

--- a/test/fixtures/cli-defaults.json
+++ b/test/fixtures/cli-defaults.json
@@ -1,0 +1,47 @@
+{
+  branch_name : '',
+  repo_url: '',
+  version : '',
+  file: 'CHANGELOG.md',
+  app_name : 'My app - Changelog',
+  grep_commits: '^fix|^feat|^docs|BREAKING',
+  tag: null,
+  logo : null,
+  intro : null,
+  debug: false,
+  sections: [
+    {
+      title: 'Bug Fixes',
+      grep: '^fix'
+    },
+    {
+      title: 'Features',
+      grep: '^feat'
+    },
+    {
+      title: 'Documentation',
+      grep: '^docs'
+    },
+    {
+      title: 'Breaking changes',
+      grep: 'BREAKING'
+    },
+    {
+      title: 'Refactor',
+      grep: '^refactor'
+    },
+    {
+      title: 'Style',
+      grep: '^style'
+    },
+    {
+      title: 'Test',
+      grep: '^test'
+    },
+    {
+      title: 'Chore',
+      grep: '^chore'
+    }
+  ]
+
+}

--- a/test/git_changelog_command.spec.js
+++ b/test/git_changelog_command.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var fs = require('fs');
+var child = require('child_process');
+var path = require('path');
+var concat = require('concat-stream');
+
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+var chaiAsPromised = require('chai-as-promised');
+
+var defaults = require('../tasks/defaults');
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+describe('command.js', function() {
+  before(function() {
+    var cliPath = path.join(__dirname, '../tasks/command.js');
+    this.cli = function(opts) {
+      opts.unshift(cliPath);
+      return child.spawn("node", opts);
+    };
+
+    /** I can't find a way to stub defaults */
+    sinon.stub(defaults, 'exports', function() {
+      var defaultsJson = fs.readFileSync('./test/fixtures/cli-defaults.json', { encoding: 'utf-8' });
+      return JSON.parse(defaultsJson);
+    });
+  });
+
+  describe('with default options', function() {
+    it('should use git remote', function() {
+      var proc = this.cli(["--debug", "true"]);
+
+      proc.stdout.pipe(concat(function(output){
+        console.log(output.toString("utf8"));
+      }));
+    });
+  });
+});


### PR DESCRIPTION
The problem is with the CLI. When given arguments `--repo_url`, the program attempted to use `url`, which was undefined.

While the fix is working, I can't test it. The second commit here is my attempt to test the file. I failed. In my test, I want to run the `tasks/command.js` as a process and inspect both the output and the file that will be written to disk. Unfortunately, I'm not able to stub the `require('default');` so I could specify my own output file. 

If you want the fix asap, I will remove the test commit so you can merge, but I'd like to be able to test the fix.

Thanks!
