### PR TITLE
Fixes parameter repo_url

### DIFF
--- a/tasks/command.js
+++ b/tasks/command.js
@@ -55,9 +55,9 @@ if (process.argv.join('').replace(/\\/g,'/').indexOf('/grunt') === -1) {
     options.intro = program.intro;
   }
 
-  if (program.url){
-    options.repo_url = program.url;
-    console.log('  - With URL %s', program.url);
+  if (program.repo_url){
+    options.repo_url = program.repo_url;
+    console.log('  - With URL %s', program.repo_url);
   }
 
   if (program.tag !== undefined){


### PR DESCRIPTION
The code expects a `url` param and the CLI expects and maps to `repo_url`. This PR fixes that.