### PR TITLE
docs(README): Follow proper style in example commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ to read on github as well as in various git tools.
 Example commit messages
 
 ```
-git commit -m "docs(readme): added documentation for explaining the commit message"
-git commit -m "refactor: Changed other things"
+git commit -m "docs(readme): Add documentation for explaining the commit message"
+git commit -m "refactor: Change other things"
 ```
 
 Closing issues : 


### PR DESCRIPTION
It looks like the example commits don't use imperative tense. This PR changes that.

Sorry about the last line in the diff... I'm not sure what vim is doing (is it adding a new line or something?), but they render identically.