### PR TITLE
Get latest tag, regardless of branch for workflows that rely on git-flow releases.

### DIFF
--- a/tasks/lib/set-defaults.js
+++ b/tasks/lib/set-defaults.js
@@ -6,7 +6,7 @@ function setDefaults() {
   debug('setting defaults');
   this.options = {};
   this.cmd = {
-    gitTag: 'git describe --tags --abbrev=0',
+    gitTag: 'git tag | tail -n1',
     gitRepoUrl: 'git config --get remote.origin.url',
     gitLog: null,
     gitLogNoTag: null

--- a/test/git_changelog_generate.spec.js
+++ b/test/git_changelog_generate.spec.js
@@ -51,7 +51,7 @@ describe('git_changelog_generate.js', function() {
       expect(changelog).to.have.property('cmd');
 
       expect(changelog).to.have.deep.property('cmd.gitTag');
-      expect(changelog.cmd.gitTag).to.equal('git describe --tags --abbrev=0');
+      expect(changelog.cmd.gitTag).to.equal('git tag | tail -n1');
 
       expect(changelog).to.have.deep.property('cmd.gitRepoUrl');
       expect(changelog.cmd.gitRepoUrl).to.equal('git config --get remote.origin.url');


### PR DESCRIPTION
Create a new release using git-flow, generate changelog and finish the release.
Next release, you won't see the previous release tag when generating a new changelog. 
