### PR TITLE
feat(providers): Add possibility to set providers in the options

### DIFF
--- a/tasks/lib/get-provider-links.js
+++ b/tasks/lib/get-provider-links.js
@@ -3,33 +3,38 @@
 var debug = require('debug')('changelog:getProviderLinks');
 
 function getProviderLinks() {
-  debug('getting provider links');
-  // This is just in case they differ their urls at some point in the future.
-  // Also brings the posibility of adding more providers
-  var providerLinks = {
-    github: {
-      issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
-      commit: '[%s](' + this.options.repo_url + '/commit/%s)'
-    },
-    bitbucket: {
-      issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
-      commit: '[%s](' + this.options.repo_url + '/commits/%s)'
-    },
-    gitlab: {
-      issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
-      commit: '[%s](' + this.options.repo_url + '/commit/%s)'
-    }
-  };
+    debug('getting provider links');
+    // This is just in case they differ their urls at some point in the future.
+    // Also brings the posibility of adding more providers
+    var providerLinks = {
+        github: {
+            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            commit: '[%s](' + this.options.repo_url + '/commit/%s)'
+        },
+        bitbucket: {
+            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            commit: '[%s](' + this.options.repo_url + '/commits/%s)'
+        },
+        gitlab: {
+            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            commit: '[%s](' + this.options.repo_url + '/commit/%s)'
+        }
+    };
 
-  if (this.options.repo_url.match(/bitbucket/)) {
-    this.provider = 'bitbucket';
-  } else if (this.options.repo_url.match(/gitlab/)) {
-    this.provider = 'gitlab';
-  } else {
-    // use github as default provider
-    this.provider = 'github';
-  }
-  this.links = providerLinks[this.provider];
+    if (this.options.provider && typeof(providerLinks[this.options.provider]) !== 'undefined') {
+        this.provider = this.options.provider;
+    }
+    else {
+        if (this.options.repo_url.match(/bitbucket/)) {
+            this.provider = 'bitbucket';
+        } else if (this.options.repo_url.match(/gitlab/)) {
+            this.provider = 'gitlab';
+        } else {
+            // use github as default provider
+            this.provider = 'github';
+        }
+    }
+    this.links = providerLinks[this.provider];
 }
 
 module.exports = getProviderLinks;

--- a/test/git_changelog_generate.spec.js
+++ b/test/git_changelog_generate.spec.js
@@ -18,961 +18,994 @@ var Q = require('q');
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
 
-describe('git_changelog_generate.js', function() {
-
-  before(function() {
-    this.randomHash = function randomHash() {
-      var hex = '0123456789abcdef';
-      var hash = '';
-      var count;
-      var random;
-
-      for (count = 0; count < 40; count++) {
-        random = Math.floor(Math.random() * 15);
-        hash += hex.charAt(random);
-      }
-
-      return hash;
-    };
-  });
-
-  describe('Changelog()', function() {
-
-    before(function() {
-      changelog.setDefaults();
-    });
-
-    it('should return an object', function() {
-      expect(changelog).to.be.an('object');
-    });
-
-    it('should initialize options property', function() {
-      expect(changelog).to.have.property('options');
-      expect(changelog).to.have.property('cmd');
-
-      expect(changelog).to.have.deep.property('cmd.gitTag');
-      expect(changelog.cmd.gitTag).to.equal('git tag | tail -n1');
-
-      expect(changelog).to.have.deep.property('cmd.gitRepoUrl');
-      expect(changelog.cmd.gitRepoUrl).to.equal('git config --get remote.origin.url');
-
-
-      expect(changelog).to.have.deep.property('cmd.gitLog');
-      expect(changelog.cmd.gitLog).to.be.null;
-
-      expect(changelog).to.have.deep.property('cmd.gitLogNoTag');
-      expect(changelog.cmd.gitLogNoTag).to.be.null;
-
-      expect(changelog).to.have.property('header', '<a name="%s">%s</a>\n# %s (%s)\n\n');
-      expect(changelog).to.have.property('emptyComponent', '$$');
-      expect(changelog).to.have.property('links', null);
-      expect(changelog).to.have.property('provider', null);
-    });
-
-    describe('.message()', function() {
-
-      beforeEach(function() {
-        changelog.setDefaults();
-      });
-
-      it('should append ";", when single arg', function() {
-        changelog.message('test');
-        expect(changelog.options.msg).to.contain('test;');
-      });
-
-      it('should separate with ":" and append ";", when multiple args', function() {
-        changelog.message('name', 'value');
-        expect(changelog.options.msg).to.contain('name: value;');
-      });
-
-    });
-
-    describe('.initOptions()', function() {
-
-      it('should store "name" if passed as an option', function() {
-        changelog.initOptions({ app_name: 'test' });
-        expect(changelog.options.app_name).to.equal('test');
-        expect(changelog.options.msg).to.contain('name: test');
-      });
-
-      it('should store "file" if passed as an option', function() {
-        changelog.initOptions({ file: 'test' });
-        expect(changelog.options.file).to.equal('test');
-        expect(changelog.options.msg).to.contain('file: test');
-      });
-
-      it('should store "changelogrc" if passed as an option', function() {
-        changelog.initOptions({ changelogrc: 'test' });
-        expect(changelog.options.changelogrc).to.equal('test');
-        expect(changelog.options.msg).to.contain('changelogrc: test');
-      });
-
-      it('should store "logo" if passed as an option', function() {
-        changelog.initOptions({ logo: 'test' });
-        expect(changelog.options.logo).to.equal('test');
-        expect(changelog.options.msg).to.contain('logo: test');
-      });
-
-      it('should store "intro" if passed as an option', function() {
-        changelog.initOptions({ intro: 'test' });
-        expect(changelog.options.intro).to.equal('test');
-        expect(changelog.options.msg).to.contain('intro: test');
-      });
-
-
-      it('should store "debug" if passed as an option', function() {
-        changelog.initOptions({ debug: 'test' });
-        expect(changelog.options.debug).to.equal('test');
-        expect(changelog.options.msg).to.contain('debug: test');
-      });
-
-      it('should store "version_name" if passed as an option', function() {
-        changelog.initOptions({ version_name: 'test' });
-        expect(changelog.options.version_name).to.equal('test');
-        expect(changelog.options.msg).to.contain('version_name: test');
-      });
-
-      it('should store any other option, but not save in msg', function() {
-        changelog.initOptions({ other: 'test' });
-        expect(changelog.options.other).to.equal('test');
-        expect(changelog.options.msg).to.not.contain('other: test');
-      });
-
-    });
-
-    describe('.getProviderLinks()', function() {
-
-      beforeEach(function() {
-        changelog.setDefaults();
-      });
-
-      it('should set provider/links to GitHub', function() {
-        var repo_url = 'https://github.com/owner/repo';
-        changelog.options.repo_url = repo_url;
-        changelog.getProviderLinks();
-
-        expect(changelog.provider).to.equal('github');
-
-        expect(changelog.links.issue).to.contain(repo_url);
-        expect(changelog.links.issue).to.contain('issues/%s');
-
-        expect(changelog.links.commit).to.contain(repo_url);
-        expect(changelog.links.commit).to.contain('commit/%s');
-      });
-
-      it('should set provider/links to BitBucket', function() {
-        var repo_url = 'https://www.bitbucket.com/owner/repo';
-        changelog.options.repo_url = repo_url;
-        changelog.getProviderLinks();
-
-        expect(changelog.provider).to.equal('bitbucket');
-
-        expect(changelog.links.issue).to.contain(repo_url);
-        expect(changelog.links.issue).to.contain('issues/%s');
-
-        expect(changelog.links.commit).to.contain(repo_url);
-        expect(changelog.links.commit).to.contain('commits/%s');
-      });
-
-      it('should set provider/links to GitLab', function() {
-        var repo_url = 'https://gitlab.com/owner/repo';
-        changelog.options.repo_url = repo_url;
-        changelog.getProviderLinks();
-
-        expect(changelog.provider).to.equal('gitlab');
-
-        expect(changelog.links.issue).to.contain(repo_url);
-        expect(changelog.links.issue).to.contain('issues/%s');
-
-        expect(changelog.links.commit).to.contain(repo_url);
-        expect(changelog.links.commit).to.contain('commit/%s');
-      });
-
-    });
-
-    describe('.getGitLogCommands()', function () {
-
-      beforeEach(function() {
-        changelog.setDefaults();
-      });
-
-      it('should generate "git log" commands for "branch"', function() {
-        var branch = 'master';
-        changelog.options.branch = branch;
-        changelog.getGitLogCommands();
-        expect(changelog.cmd.gitLog).to.include('git log ')
-            .and.include('..' + branch);
-
-        expect(changelog.cmd.gitLogNoTag).to.include('git log ' + branch);
-      });
-
-    });
-
-    describe('.init()', function () {
-
-      after(function() {
-        changelog.getRepoUrl.restore();
-      });
-
-      it('should succeed with options when repo specified or remote found', function() {
-        var options = {
-          app_name: 'app',
-          repo_url: 'https://github.com/owner/repo'
-        };
-        return expect(changelog.init(options))
-          .to.eventually.be.fulfilled;
-      });
-
-      it('should fail when no repo specified and no remote found', function() {
-        var options = {
-          app_name: 'app'
-        };
-
-        // simulate no remote returned by .getRepoUrl()
-        sinon.stub(changelog, 'getRepoUrl').returns(Q.reject());
-
-        return expect(changelog.init(options))
-          .to.eventually.be.rejected;
-      });
-
-    });
-
-    describe('.parseRawCommit()', function() {
-
-      it('should parse raw commit', function() {
-        var msg = changelog.parseRawCommit(
-            '9b1aff905b638aa274a5fc8f88662df446d374bd\n' +
-            'feat(scope): broadcast $destroy event on scope destruction\n' +
-            'perf testing shows that in chrome this change adds 5-15% overhead\n' +
-            'when destroying 10k nested scopes where each scope has a $destroy listener\n');
-
-        expect(msg.type).to.equal('feat');
-        expect(msg.hash).to.equal('9b1aff905b638aa274a5fc8f88662df446d374bd');
-        expect(msg.subject).to.equal('broadcast $destroy event on scope destruction');
-        expect(msg.body).to.equal('perf testing shows that in chrome this change adds 5-15% overhead\n' +
-            'when destroying 10k nested scopes where each scope has a $destroy listener\n');
-        expect(msg.component).to.equal('scope');
-      });
-
-      it('should parse closed issues', function() {
-        var msg = changelog.parseRawCommit(
-            '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
-            'feat(ng-list): Allow custom separator\n' +
-            'bla bla bla\n\n' +
-            'Closes #123\nCloses #25\n');
-
-        expect(msg.closes[0]).to.equal(123);
-        expect(msg.closes[1]).to.equal(25);
-      });
-
-      it('should parse closed issues in the body comment', function() {
-        var msg = changelog.parseRawCommit(
-            '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
-            'feat(ng-list): Allow custom separator and Closes #33\n');
-
-        expect(msg.closes[0]).to.equal(33);
-      });
-
-      it('should parse breaking changes', function() {
-        var msg = changelog.parseRawCommit(
-            '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
-            'feat(ng-list): Allow custom separator\n' +
-            'bla bla bla\n\n' +
-            'BREAKING CHANGE: first breaking change\nsomething else\n' +
-            'another line with more info\n');
-
-        expect(msg.breaking).to.equal(' first breaking change\nsomething else\nanother line with more info\n');
-      });
-
-      it('should add everything as a message if there are 2 sections', function(){
-        var msg = changelog.parseRawCommit(
-          '13f31602f396bc269076ab4d389cfd8ca94b20ba\n'+
-          'feat(ad): make new ad\n' +
-          'some note here\n' +
-          'reg(ad): need a walk through\n');
-
-        expect(msg.body).to.equals('some note here\nreg(ad): need a walk through\n');
-      });
-
-      it('should organize commits', function() {
-        var msg = changelog.parseRawCommit(
-            '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
-            'feat(ng-list): Allow custom separator\n' +
-            'bla bla bla\n\n' +
-            'BREAKING CHANGE: first breaking change\nsomething else\n' +
-            'another line with more info\n');
-
-        var sections = [{
-          title: 'Bug Fixes',
-          grep: '^fix'
-        }];
-
-        var commits = [];
-
-        for(var i = 0; i < 10; i++){
-          commits.push(changelog.parseRawCommit(
-            '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
-            'fix(myModule): Allow custom separator\n' +
-            'bla bla bla\n\n'));
-        }
-
-        sections = changelog.organizeCommits(commits, sections);
-        expect(sections[0].components[0].name).to.equal('mymodule');
-        expect(sections[0].components[0].commits.length).to.equal(10);
-      });
-
-    });
-
-    describe('.linkToIssue()', function() {
-
-      it('should issue links based on "repo_url" and "issue" number', function() {
-        var repo_url = 'https://github.com/owner/repo';
-        var issue;
-        var link;
-
-        changelog.options.repo_url = repo_url;
-        changelog.getProviderLinks();
-
-        for (issue = 100; issue < 110; issue++) {
-          link = changelog.linkToIssue(issue);
-          expect(link).to.contain(repo_url);
-          expect(link).to.contain('issue');
-          expect(link).to.contain('#' + issue.toString());
-        }
-      });
-
-    });
-
-    describe('.linkToCommit()', function() {
-
-      it('should issue links based on "repo_url" and "issue" number', function() {
-        var repo_url = 'https://github.com/owner/repo';
-        var index;
-        var hash;
-        var link;
-
-        changelog.options.repo_url = repo_url;
-        changelog.getProviderLinks();
-
-        for (index = 0; index < 10; index++) {
-          hash = this.randomHash();
-          link = changelog.linkToCommit(hash);
-          expect(link).to.contain(repo_url);
-          expect(link).to.contain('[' + hash.substr(0, 8) + ']');
-          expect(link).to.contain(hash.toString());
-        }
-      });
-
-    });
-
-    describe('.currentDate()', function() {
-
-      it('should return the current data in "yyyy-mm-dd" format', function() {
-        var currentDate = changelog.currentDate();
-        var now = new Date();
-
-        expect(currentDate).to.be.a('string');
-        expect(currentDate).to.have.length(10);
-        expect(parseInt(currentDate.substr(0,4))).to.equal(now.getFullYear());
-        expect(parseInt(currentDate.substr(5,4))).to.equal(now.getMonth() + 1);
-        expect(parseInt(currentDate.substr(8,4))).to.equal(now.getDate());
-      });
-
-    });
-
-    xdescribe('.printSection()', function() {
-
-    });
-
-    describe('.printSalute()', function() {
-
-      beforeEach(function() {
-        this.stream = {
-          write: sinon.stub()
-        };
-        changelog.printSalute(this.stream);
-      });
-
-      afterEach(function() {
-        this.stream = null;
-      });
-
-      it('should call stream.write() twice', function() {
-        expect(this.stream.write).to.have.been.calledTwice;
-      });
-
-      it('should call stream.write() with git-changelog message', function() {
-        expect(this.stream.write).to.have.been.calledWithMatch(/Generated with \[git-changelog\]/);
-      });
-
-    });
-
-    describe('.readGitLog()', function() {
-
-      before(function(done) {
-        changelog.init({ app_name: 'test' }).then(function() {
-          this.exec = sinon.stub(child, 'exec', function(cmd, opts, cb) {
-            var commits = fs.readFileSync('./test/fixtures/list.txt', { encoding: 'utf-8' });
-            cb(null, commits, null);
-          });
-          done();
-        }.bind(this));
-      });
-
-      after(function () {
-        this.exec.restore();
-      });
-
-      it('should read log and parse commits', function() {
-        return expect(changelog.readGitLog(changelog.cmd.gitLog, 'tag'))
-          .to.eventually.be.fulfilled
-          .then(function(commits) {
-            expect(this.exec).to.have.been.calledOnce;
-            expect(this.exec).to.have.been.calledWithMatch(/^git log/);
-            expect(commits).to.be.an('array');
-            expect(commits).to.have.length(6);
-          }.bind(this));
-      });
-
-    });
-
-    describe('.writeChangelog()', function() {
-
-      describe('without breaking commits', function() {
-        var sections = [
-          {
-            title: 'Bug Fixes',
-            grep: '^fix'
-          },
-          {
-            title: 'Features',
-            grep: '^feat'
-          },
-          {
-            title: 'Documentation',
-            grep: '^docs'
-          },
-          {
-            title: 'Refactor',
-            grep: '^refactor'
-          },
-          {
-            title: 'Style',
-            grep: '^style'
-          },
-          {
-            title: 'Test',
-            grep: '^test'
-          },
-          {
-            title: 'Chore',
-            grep: '^chore'
-          },
-          {
-            title: 'Breaking changes',
-            grep: 'BREAKING'
-          } 
-        ];
-
-        before(function(done) {
-          this.timeout = 10000;
-         
-          this.commits = require('./fixtures/commits.js').withoutBreaking;
-
-          sinon.stub(changelog, 'printSalute');
-          sinon.stub(changelog, 'printSection');
-          sinon.stub(changelog, 'printHeader');
-
-          changelog.initOptions({ app_name: 'app', version_name: 'version_name', sections: sections, template: false });
-          changelog.writeChangelog(this.commits)
-          .then(function() {
-            done();
-          })
-          .catch(function(err){
-            console.log('error', err);
-          });
-        });
-
-        after(function() {
-          changelog.printSection.restore();
-          changelog.printHeader.restore();
-          changelog.printSalute.restore();
-        });
-
-        it('should write the header to the stream', function() {
-          expect(changelog.printHeader).to.have.been.calledOnce;
-        });
-
-        it('should print 3 sections', function() {
-          expect(changelog.printSection.callCount).to.equal(3);
-        });
-
-        it('should print salute', function() {
-          expect(changelog.printSalute).to.have.been.calledOnce;
-        });
-
-      });
-
-      describe('with breaking commits', function() {
-        var sections = [
-          {
-            title: 'Bug Fixes',
-            grep: '^fix'
-          },
-          {
-            title: 'Features',
-            grep: '^feat'
-          },
-          {
-            title: 'Documentation',
-            grep: '^docs'
-          },
-          {
-            title: 'Refactor',
-            grep: '^refactor'
-          },
-          {
-            title: 'Style',
-            grep: '^style'
-          },
-          {
-            title: 'Test',
-            grep: '^test'
-          },
-          {
-            title: 'Chore',
-            grep: '^chore'
-          },
-          {
-            title: 'Breaking Changes',
-            grep: 'BREAKING'
-          }
-        ];
-
-        before(function(done) {
-          
-          this.commits = require('./fixtures/commits.js').withBreaking;
-
-          sinon.stub(changelog, 'organizeCommits', function(commits, sections) {
-            return [{
-              type: 'BREAKING',
-              commits: [{
-                closes: [],
-                breaks: [],
-                hash: '1d4f604363094d4eee3b4d7b1ca01133edaad344',
-                subject: 'did 2 thing',
-                body: '',
-                type: 'feat',
-                component: '',
-                breaking: true
-              }],
-              components:[{
-                name: '$scope',
-                commits: [{
-                  closes: [],
-                  breaks: [],
-                  hash: '1d4f604363012394d4eee3b4d7b1ca01133edaad344',
-                  subject: 'did 4 thing',
-                  body: '',
-                  type: 'feat',
-                  component: '$scope',
-                  breaking: true
-                }]
-              }]
-            }];
-          });
-          sinon.stub(changelog, 'printSalute');
-          sinon.stub(changelog, 'printSection');
-          sinon.stub(changelog, 'printHeader');
-
-          changelog.initOptions({ app_name: 'app', version_name: 'version_name', sections: sections, template:false });
-          changelog.writeChangelog(this.commits).then(function() {
-            done();
-          });
-        });
-
-        after(function() {
-          changelog.organizeCommits.restore();
-          changelog.printSection.restore();
-          changelog.printSalute.restore();
-          changelog.printHeader.restore();
-        });
-
-        it('should organize commits', function() {
-          expect(changelog.organizeCommits).to.have.been.calledOnce;
-          expect(changelog.organizeCommits).to.have.been.calledWith(this.commits);
-        });
-
-        it('should write the header to the stream', function() {
-          expect(changelog.printHeader).to.have.been.calledOnce;
-        });
-
-        it('should print 1 sections', function() {
-          expect(changelog.printSection.callCount).to.equal(1);
-        });
-
-        it('should print salute', function() {
-          expect(changelog.printSalute).to.have.been.calledOnce;
-        });
-
-      });
-
-    });
-
-    describe('.organizeCommits()', function() {
-      function findItem(key, value){
-        return function (item){
-          return item[key] === value;
-        };
-      }
-
-      describe('without breaking commits', function () {
-
-        before(function() {
-          changelog.setDefaults();
-          this.sections = [
-            {
-              title: 'Bug Fixes',
-              grep: '^fix'
-            },
-            {
-              title: 'Features',
-              grep: '^feat'
-            },
-            {
-              title: 'Documentation',
-              grep: '^docs'
-            },
-            {
-              title: 'Breaking changes',
-              grep: 'BREAKING'
-            },
-            {
-              title: 'Refactor',
-              grep: '^refactor'
-            },
-            {
-              title: 'Style',
-              grep: '^style'
-            },
-            {
-              title: 'Test',
-              grep: '^test'
-            },
-            {
-              title: 'Chore',
-              grep: '^chore'
+describe('git_changelog_generate.js', function () {
+
+    before(function () {
+        this.randomHash = function randomHash() {
+            var hex = '0123456789abcdef';
+            var hash = '';
+            var count;
+            var random;
+
+            for (count = 0; count < 40; count++) {
+                random = Math.floor(Math.random() * 15);
+                hash += hex.charAt(random);
             }
-          ];
 
-          this.commits = require('./fixtures/commits.js').withoutBreaking;
-          this.sections = changelog.organizeCommits(this.commits, this.sections);
+            return hash;
+        };
+    });
+
+    describe('Changelog()', function () {
+
+        before(function () {
+            changelog.setDefaults();
         });
 
-        it('should return 3 sections', function() {
-          expect(this.sections.length).to.equal(3);
+        it('should return an object', function () {
+            expect(changelog).to.be.an('object');
         });
 
-        it('should fix section to have 1 commit', function() {
-          expect(this.sections.find(findItem('type', 'fix')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+        it('should initialize options property', function () {
+            expect(changelog).to.have.property('options');
+            expect(changelog).to.have.property('cmd');
+
+            expect(changelog).to.have.deep.property('cmd.gitTag');
+            expect(changelog.cmd.gitTag).to.equal('git tag | tail -n1');
+
+            expect(changelog).to.have.deep.property('cmd.gitRepoUrl');
+            expect(changelog.cmd.gitRepoUrl).to.equal('git config --get remote.origin.url');
+
+
+            expect(changelog).to.have.deep.property('cmd.gitLog');
+            expect(changelog.cmd.gitLog).to.be.null;
+
+            expect(changelog).to.have.deep.property('cmd.gitLogNoTag');
+            expect(changelog.cmd.gitLogNoTag).to.be.null;
+
+            expect(changelog).to.have.property('header', '<a name="%s">%s</a>\n# %s (%s)\n\n');
+            expect(changelog).to.have.property('emptyComponent', '$$');
+            expect(changelog).to.have.property('links', null);
+            expect(changelog).to.have.property('provider', null);
         });
 
-        it('should feat section to have 1 commit', function() {
-          expect(this.sections.find(findItem('type', 'feat')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+        describe('.message()', function () {
+
+            beforeEach(function () {
+                changelog.setDefaults();
+            });
+
+            it('should append ";", when single arg', function () {
+                changelog.message('test');
+                expect(changelog.options.msg).to.contain('test;');
+            });
+
+            it('should separate with ":" and append ";", when multiple args', function () {
+                changelog.message('name', 'value');
+                expect(changelog.options.msg).to.contain('name: value;');
+            });
+
         });
 
-        it('should breaks section to be empty', function() {
-          expect(this.sections.find(findItem('type', 'BREAKING'))).to.equal(undefined);
+        describe('.initOptions()', function () {
+
+            it('should store "name" if passed as an option', function () {
+                changelog.initOptions({app_name: 'test'});
+                expect(changelog.options.app_name).to.equal('test');
+                expect(changelog.options.msg).to.contain('name: test');
+            });
+
+            it('should store "file" if passed as an option', function () {
+                changelog.initOptions({file: 'test'});
+                expect(changelog.options.file).to.equal('test');
+                expect(changelog.options.msg).to.contain('file: test');
+            });
+
+            it('should store "changelogrc" if passed as an option', function () {
+                changelog.initOptions({changelogrc: 'test'});
+                expect(changelog.options.changelogrc).to.equal('test');
+                expect(changelog.options.msg).to.contain('changelogrc: test');
+            });
+
+            it('should store "logo" if passed as an option', function () {
+                changelog.initOptions({logo: 'test'});
+                expect(changelog.options.logo).to.equal('test');
+                expect(changelog.options.msg).to.contain('logo: test');
+            });
+
+            it('should store "intro" if passed as an option', function () {
+                changelog.initOptions({intro: 'test'});
+                expect(changelog.options.intro).to.equal('test');
+                expect(changelog.options.msg).to.contain('intro: test');
+            });
+
+
+            it('should store "debug" if passed as an option', function () {
+                changelog.initOptions({debug: 'test'});
+                expect(changelog.options.debug).to.equal('test');
+                expect(changelog.options.msg).to.contain('debug: test');
+            });
+
+            it('should store "version_name" if passed as an option', function () {
+                changelog.initOptions({version_name: 'test'});
+                expect(changelog.options.version_name).to.equal('test');
+                expect(changelog.options.msg).to.contain('version_name: test');
+            });
+
+            it('should store any other option, but not save in msg', function () {
+                changelog.initOptions({other: 'test'});
+                expect(changelog.options.other).to.equal('test');
+                expect(changelog.options.msg).to.not.contain('other: test');
+            });
+
         });
 
-        it('should style section to be empty', function() {
-          expect(this.sections.find(findItem('type', 'style'))).to.equal(undefined);
+        describe('.getProviderLinks()', function () {
+
+            beforeEach(function () {
+                changelog.setDefaults();
+            });
+
+            it('should take the provider passed in the options in priority', function () {
+                var repo_url = 'https://github.com/owner/repo';
+                changelog.options.repo_url = repo_url;
+
+                changelog.options.provider = 'gitlab';
+                changelog.getProviderLinks();
+                expect(changelog.provider).to.equal('gitlab');
+
+            });
+            it('should ignore unknown providers', function () {
+                var repo_url = 'https://github.com/owner/repo';
+                changelog.options.repo_url = repo_url;
+
+                changelog.options.provider = 'foobar';
+                changelog.getProviderLinks();
+                expect(changelog.provider).to.equal('github');
+
+            });
+
+
+
+
+
+            it('should set provider/links to GitHub', function () {
+                var repo_url = 'https://github.com/owner/repo';
+                changelog.options.repo_url = repo_url;
+                changelog.getProviderLinks();
+
+                expect(changelog.provider).to.equal('github');
+
+                expect(changelog.links.issue).to.contain(repo_url);
+                expect(changelog.links.issue).to.contain('issues/%s');
+
+                expect(changelog.links.commit).to.contain(repo_url);
+                expect(changelog.links.commit).to.contain('commit/%s');
+            });
+
+            it('should set provider/links to BitBucket', function () {
+                var repo_url = 'https://www.bitbucket.com/owner/repo';
+                changelog.options.repo_url = repo_url;
+                changelog.getProviderLinks();
+
+                expect(changelog.provider).to.equal('bitbucket');
+
+                expect(changelog.links.issue).to.contain(repo_url);
+                expect(changelog.links.issue).to.contain('issues/%s');
+
+                expect(changelog.links.commit).to.contain(repo_url);
+                expect(changelog.links.commit).to.contain('commits/%s');
+            });
+
+            it('should set provider/links to GitLab', function () {
+                var repo_url = 'https://gitlab.com/owner/repo';
+                changelog.options.repo_url = repo_url;
+                changelog.getProviderLinks();
+
+                expect(changelog.provider).to.equal('gitlab');
+
+                expect(changelog.links.issue).to.contain(repo_url);
+                expect(changelog.links.issue).to.contain('issues/%s');
+
+                expect(changelog.links.commit).to.contain(repo_url);
+                expect(changelog.links.commit).to.contain('commit/%s');
+            });
+
         });
 
-        it('should refactor section be empty', function() {
-          expect(this.sections.find(findItem('type', 'refactor'))).to.equal(undefined);
+        describe('.getGitLogCommands()', function () {
+
+            beforeEach(function () {
+                changelog.setDefaults();
+            });
+
+            it('should generate "git log" commands for "branch"', function () {
+                var branch = 'master';
+                changelog.options.branch = branch;
+                changelog.getGitLogCommands();
+                expect(changelog.cmd.gitLog).to.include('git log ')
+                    .and.include('..' + branch);
+
+                expect(changelog.cmd.gitLogNoTag).to.include('git log ' + branch);
+            });
+
         });
 
-        it('should test section to be empty', function() {
-          expect(this.sections.find(findItem('type', 'test'))).to.equal(undefined);
+        describe('.init()', function () {
+
+            after(function () {
+                changelog.getRepoUrl.restore();
+            });
+
+            it('should succeed with options when repo specified or remote found', function () {
+                var options = {
+                    app_name: 'app',
+                    repo_url: 'https://github.com/owner/repo'
+                };
+                return expect(changelog.init(options))
+                    .to.eventually.be.fulfilled;
+            });
+
+            it('should fail when no repo specified and no remote found', function () {
+                var options = {
+                    app_name: 'app'
+                };
+
+                // simulate no remote returned by .getRepoUrl()
+                sinon.stub(changelog, 'getRepoUrl').returns(Q.reject());
+
+                return expect(changelog.init(options))
+                    .to.eventually.be.rejected;
+            });
+
         });
 
-        it('should chore section to have 1 commit', function() {
-          expect(this.sections.find(findItem('type', 'chore')).components.find(findItem('name', '$scope')).commits.length).to.equal(3);
+        describe('.parseRawCommit()', function () {
+
+            it('should parse raw commit', function () {
+                var msg = changelog.parseRawCommit(
+                    '9b1aff905b638aa274a5fc8f88662df446d374bd\n' +
+                    'feat(scope): broadcast $destroy event on scope destruction\n' +
+                    'perf testing shows that in chrome this change adds 5-15% overhead\n' +
+                    'when destroying 10k nested scopes where each scope has a $destroy listener\n');
+
+                expect(msg.type).to.equal('feat');
+                expect(msg.hash).to.equal('9b1aff905b638aa274a5fc8f88662df446d374bd');
+                expect(msg.subject).to.equal('broadcast $destroy event on scope destruction');
+                expect(msg.body).to.equal('perf testing shows that in chrome this change adds 5-15% overhead\n' +
+                    'when destroying 10k nested scopes where each scope has a $destroy listener\n');
+                expect(msg.component).to.equal('scope');
+            });
+
+            it('should parse closed issues', function () {
+                var msg = changelog.parseRawCommit(
+                    '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+                    'feat(ng-list): Allow custom separator\n' +
+                    'bla bla bla\n\n' +
+                    'Closes #123\nCloses #25\n');
+
+                expect(msg.closes[0]).to.equal(123);
+                expect(msg.closes[1]).to.equal(25);
+            });
+
+            it('should parse closed issues in the body comment', function () {
+                var msg = changelog.parseRawCommit(
+                    '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+                    'feat(ng-list): Allow custom separator and Closes #33\n');
+
+                expect(msg.closes[0]).to.equal(33);
+            });
+
+            it('should parse breaking changes', function () {
+                var msg = changelog.parseRawCommit(
+                    '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+                    'feat(ng-list): Allow custom separator\n' +
+                    'bla bla bla\n\n' +
+                    'BREAKING CHANGE: first breaking change\nsomething else\n' +
+                    'another line with more info\n');
+
+                expect(msg.breaking).to.equal(' first breaking change\nsomething else\nanother line with more info\n');
+            });
+
+            it('should add everything as a message if there are 2 sections', function () {
+                var msg = changelog.parseRawCommit(
+                    '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+                    'feat(ad): make new ad\n' +
+                    'some note here\n' +
+                    'reg(ad): need a walk through\n');
+
+                expect(msg.body).to.equals('some note here\nreg(ad): need a walk through\n');
+            });
+
+            it('should organize commits', function () {
+                var msg = changelog.parseRawCommit(
+                    '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+                    'feat(ng-list): Allow custom separator\n' +
+                    'bla bla bla\n\n' +
+                    'BREAKING CHANGE: first breaking change\nsomething else\n' +
+                    'another line with more info\n');
+
+                var sections = [{
+                    title: 'Bug Fixes',
+                    grep: '^fix'
+                }];
+
+                var commits = [];
+
+                for (var i = 0; i < 10; i++) {
+                    commits.push(changelog.parseRawCommit(
+                        '13f31602f396bc269076ab4d389cfd8ca94b20ba\n' +
+                        'fix(myModule): Allow custom separator\n' +
+                        'bla bla bla\n\n'));
+                }
+
+                sections = changelog.organizeCommits(commits, sections);
+                expect(sections[0].components[0].name).to.equal('mymodule');
+                expect(sections[0].components[0].commits.length).to.equal(10);
+            });
+
         });
 
-        it('should docs section to be empty', function() {
-          expect(this.sections.find(findItem('type', 'docs'))).to.equal(undefined);
+        describe('.linkToIssue()', function () {
+
+            it('should issue links based on "repo_url" and "issue" number', function () {
+                var repo_url = 'https://github.com/owner/repo';
+                var issue;
+                var link;
+
+                changelog.options.repo_url = repo_url;
+                changelog.getProviderLinks();
+
+                for (issue = 100; issue < 110; issue++) {
+                    link = changelog.linkToIssue(issue);
+                    expect(link).to.contain(repo_url);
+                    expect(link).to.contain('issue');
+                    expect(link).to.contain('#' + issue.toString());
+                }
+            });
+
         });
 
-      });
+        describe('.linkToCommit()', function () {
 
-      describe('with breaking commits', function () {
+            it('should issue links based on "repo_url" and "issue" number', function () {
+                var repo_url = 'https://github.com/owner/repo';
+                var index;
+                var hash;
+                var link;
 
-        before(function() {
-          changelog.setDefaults();
-          this.sections = [
-            {
-              title: 'Bug Fixes',
-              grep: '^fix'
-            },
-            {
-              title: 'Features',
-              grep: '^feat'
-            },
-            {
-              title: 'Documentation',
-              grep: '^docs'
-            },
-            {
-              title: 'Breaking changes',
-              grep: 'BREAKING'
-            },
-            {
-              title: 'Refactor',
-              grep: '^refactor'
-            },
-            {
-              title: 'Style',
-              grep: '^style'
-            },
-            {
-              title: 'Test',
-              grep: '^test'
-            },
-            {
-              title: 'Chore',
-              grep: '^chore'
+                changelog.options.repo_url = repo_url;
+                changelog.getProviderLinks();
+
+                for (index = 0; index < 10; index++) {
+                    hash = this.randomHash();
+                    link = changelog.linkToCommit(hash);
+                    expect(link).to.contain(repo_url);
+                    expect(link).to.contain('[' + hash.substr(0, 8) + ']');
+                    expect(link).to.contain(hash.toString());
+                }
+            });
+
+        });
+
+        describe('.currentDate()', function () {
+
+            it('should return the current data in "yyyy-mm-dd" format', function () {
+                var currentDate = changelog.currentDate();
+                var now = new Date();
+
+                expect(currentDate).to.be.a('string');
+                expect(currentDate).to.have.length(10);
+                expect(parseInt(currentDate.substr(0, 4))).to.equal(now.getFullYear());
+                expect(parseInt(currentDate.substr(5, 4))).to.equal(now.getMonth() + 1);
+                expect(parseInt(currentDate.substr(8, 4))).to.equal(now.getDate());
+            });
+
+        });
+
+        xdescribe('.printSection()', function () {
+
+        });
+
+        describe('.printSalute()', function () {
+
+            beforeEach(function () {
+                this.stream = {
+                    write: sinon.stub()
+                };
+                changelog.printSalute(this.stream);
+            });
+
+            afterEach(function () {
+                this.stream = null;
+            });
+
+            it('should call stream.write() twice', function () {
+                expect(this.stream.write).to.have.been.calledTwice;
+            });
+
+            it('should call stream.write() with git-changelog message', function () {
+                expect(this.stream.write).to.have.been.calledWithMatch(/Generated with \[git-changelog\]/);
+            });
+
+        });
+
+        describe('.readGitLog()', function () {
+
+            before(function (done) {
+                changelog.init({app_name: 'test'}).then(function () {
+                    this.exec = sinon.stub(child, 'exec', function (cmd, opts, cb) {
+                        var commits = fs.readFileSync('./test/fixtures/list.txt', {encoding: 'utf-8'});
+                        cb(null, commits, null);
+                    });
+                    done();
+                }.bind(this));
+            });
+
+            after(function () {
+                this.exec.restore();
+            });
+
+            it('should read log and parse commits', function () {
+                return expect(changelog.readGitLog(changelog.cmd.gitLog, 'tag'))
+                    .to.eventually.be.fulfilled
+                    .then(function (commits) {
+                        expect(this.exec).to.have.been.calledOnce;
+                        expect(this.exec).to.have.been.calledWithMatch(/^git log/);
+                        expect(commits).to.be.an('array');
+                        expect(commits).to.have.length(6);
+                    }.bind(this));
+            });
+
+        });
+
+        describe('.writeChangelog()', function () {
+
+            describe('without breaking commits', function () {
+                var sections = [
+                    {
+                        title: 'Bug Fixes',
+                        grep: '^fix'
+                    },
+                    {
+                        title: 'Features',
+                        grep: '^feat'
+                    },
+                    {
+                        title: 'Documentation',
+                        grep: '^docs'
+                    },
+                    {
+                        title: 'Refactor',
+                        grep: '^refactor'
+                    },
+                    {
+                        title: 'Style',
+                        grep: '^style'
+                    },
+                    {
+                        title: 'Test',
+                        grep: '^test'
+                    },
+                    {
+                        title: 'Chore',
+                        grep: '^chore'
+                    },
+                    {
+                        title: 'Breaking changes',
+                        grep: 'BREAKING'
+                    }
+                ];
+
+                before(function (done) {
+                    this.timeout = 10000;
+
+                    this.commits = require('./fixtures/commits.js').withoutBreaking;
+
+                    sinon.stub(changelog, 'printSalute');
+                    sinon.stub(changelog, 'printSection');
+                    sinon.stub(changelog, 'printHeader');
+
+                    changelog.initOptions({
+                        app_name: 'app',
+                        version_name: 'version_name',
+                        sections: sections,
+                        template: false
+                    });
+                    changelog.writeChangelog(this.commits)
+                        .then(function () {
+                            done();
+                        })
+                        .catch(function (err) {
+                            console.log('error', err);
+                        });
+                });
+
+                after(function () {
+                    changelog.printSection.restore();
+                    changelog.printHeader.restore();
+                    changelog.printSalute.restore();
+                });
+
+                it('should write the header to the stream', function () {
+                    expect(changelog.printHeader).to.have.been.calledOnce;
+                });
+
+                it('should print 3 sections', function () {
+                    expect(changelog.printSection.callCount).to.equal(3);
+                });
+
+                it('should print salute', function () {
+                    expect(changelog.printSalute).to.have.been.calledOnce;
+                });
+
+            });
+
+            describe('with breaking commits', function () {
+                var sections = [
+                    {
+                        title: 'Bug Fixes',
+                        grep: '^fix'
+                    },
+                    {
+                        title: 'Features',
+                        grep: '^feat'
+                    },
+                    {
+                        title: 'Documentation',
+                        grep: '^docs'
+                    },
+                    {
+                        title: 'Refactor',
+                        grep: '^refactor'
+                    },
+                    {
+                        title: 'Style',
+                        grep: '^style'
+                    },
+                    {
+                        title: 'Test',
+                        grep: '^test'
+                    },
+                    {
+                        title: 'Chore',
+                        grep: '^chore'
+                    },
+                    {
+                        title: 'Breaking Changes',
+                        grep: 'BREAKING'
+                    }
+                ];
+
+                before(function (done) {
+
+                    this.commits = require('./fixtures/commits.js').withBreaking;
+
+                    sinon.stub(changelog, 'organizeCommits', function (commits, sections) {
+                        return [{
+                            type: 'BREAKING',
+                            commits: [{
+                                closes: [],
+                                breaks: [],
+                                hash: '1d4f604363094d4eee3b4d7b1ca01133edaad344',
+                                subject: 'did 2 thing',
+                                body: '',
+                                type: 'feat',
+                                component: '',
+                                breaking: true
+                            }],
+                            components: [{
+                                name: '$scope',
+                                commits: [{
+                                    closes: [],
+                                    breaks: [],
+                                    hash: '1d4f604363012394d4eee3b4d7b1ca01133edaad344',
+                                    subject: 'did 4 thing',
+                                    body: '',
+                                    type: 'feat',
+                                    component: '$scope',
+                                    breaking: true
+                                }]
+                            }]
+                        }];
+                    });
+                    sinon.stub(changelog, 'printSalute');
+                    sinon.stub(changelog, 'printSection');
+                    sinon.stub(changelog, 'printHeader');
+
+                    changelog.initOptions({
+                        app_name: 'app',
+                        version_name: 'version_name',
+                        sections: sections,
+                        template: false
+                    });
+                    changelog.writeChangelog(this.commits).then(function () {
+                        done();
+                    });
+                });
+
+                after(function () {
+                    changelog.organizeCommits.restore();
+                    changelog.printSection.restore();
+                    changelog.printSalute.restore();
+                    changelog.printHeader.restore();
+                });
+
+                it('should organize commits', function () {
+                    expect(changelog.organizeCommits).to.have.been.calledOnce;
+                    expect(changelog.organizeCommits).to.have.been.calledWith(this.commits);
+                });
+
+                it('should write the header to the stream', function () {
+                    expect(changelog.printHeader).to.have.been.calledOnce;
+                });
+
+                it('should print 1 sections', function () {
+                    expect(changelog.printSection.callCount).to.equal(1);
+                });
+
+                it('should print salute', function () {
+                    expect(changelog.printSalute).to.have.been.calledOnce;
+                });
+
+            });
+
+        });
+
+        describe('.organizeCommits()', function () {
+            function findItem(key, value) {
+                return function (item) {
+                    return item[key] === value;
+                };
             }
-          ];
-          var repo_url = 'https://github.com/owner/repo';
-          changelog.options.repo_url = repo_url;
-          changelog.getProviderLinks();
 
-          this.commits = require('./fixtures/commits.js').withBreaking;
-          this.sections = changelog.organizeCommits(this.commits, this.sections);
+            describe('without breaking commits', function () {
+
+                before(function () {
+                    changelog.setDefaults();
+                    this.sections = [
+                        {
+                            title: 'Bug Fixes',
+                            grep: '^fix'
+                        },
+                        {
+                            title: 'Features',
+                            grep: '^feat'
+                        },
+                        {
+                            title: 'Documentation',
+                            grep: '^docs'
+                        },
+                        {
+                            title: 'Breaking changes',
+                            grep: 'BREAKING'
+                        },
+                        {
+                            title: 'Refactor',
+                            grep: '^refactor'
+                        },
+                        {
+                            title: 'Style',
+                            grep: '^style'
+                        },
+                        {
+                            title: 'Test',
+                            grep: '^test'
+                        },
+                        {
+                            title: 'Chore',
+                            grep: '^chore'
+                        }
+                    ];
+
+                    this.commits = require('./fixtures/commits.js').withoutBreaking;
+                    this.sections = changelog.organizeCommits(this.commits, this.sections);
+                });
+
+                it('should return 3 sections', function () {
+                    expect(this.sections.length).to.equal(3);
+                });
+
+                it('should fix section to have 1 commit', function () {
+                    expect(this.sections.find(findItem('type', 'fix')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+                });
+
+                it('should feat section to have 1 commit', function () {
+                    expect(this.sections.find(findItem('type', 'feat')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+                });
+
+                it('should breaks section to be empty', function () {
+                    expect(this.sections.find(findItem('type', 'BREAKING'))).to.equal(undefined);
+                });
+
+                it('should style section to be empty', function () {
+                    expect(this.sections.find(findItem('type', 'style'))).to.equal(undefined);
+                });
+
+                it('should refactor section be empty', function () {
+                    expect(this.sections.find(findItem('type', 'refactor'))).to.equal(undefined);
+                });
+
+                it('should test section to be empty', function () {
+                    expect(this.sections.find(findItem('type', 'test'))).to.equal(undefined);
+                });
+
+                it('should chore section to have 1 commit', function () {
+                    expect(this.sections.find(findItem('type', 'chore')).components.find(findItem('name', '$scope')).commits.length).to.equal(3);
+                });
+
+                it('should docs section to be empty', function () {
+                    expect(this.sections.find(findItem('type', 'docs'))).to.equal(undefined);
+                });
+
+            });
+
+            describe('with breaking commits', function () {
+
+                before(function () {
+                    changelog.setDefaults();
+                    this.sections = [
+                        {
+                            title: 'Bug Fixes',
+                            grep: '^fix'
+                        },
+                        {
+                            title: 'Features',
+                            grep: '^feat'
+                        },
+                        {
+                            title: 'Documentation',
+                            grep: '^docs'
+                        },
+                        {
+                            title: 'Breaking changes',
+                            grep: 'BREAKING'
+                        },
+                        {
+                            title: 'Refactor',
+                            grep: '^refactor'
+                        },
+                        {
+                            title: 'Style',
+                            grep: '^style'
+                        },
+                        {
+                            title: 'Test',
+                            grep: '^test'
+                        },
+                        {
+                            title: 'Chore',
+                            grep: '^chore'
+                        }
+                    ];
+                    var repo_url = 'https://github.com/owner/repo';
+                    changelog.options.repo_url = repo_url;
+                    changelog.getProviderLinks();
+
+                    this.commits = require('./fixtures/commits.js').withBreaking;
+                    this.sections = changelog.organizeCommits(this.commits, this.sections);
+                });
+
+                it('should return 4 sections', function () {
+                    expect(this.sections.length).to.equal(4);
+                });
+
+                it('should fix section to have 1 commit', function () {
+                    expect(this.sections.find(findItem('type', 'fix')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+                });
+
+                it('should feat section to have 1 commit', function () {
+                    expect(this.sections.find(findItem('type', 'feat')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+                });
+
+                it('should breaks have 1 component and 2 comits', function () {
+                    expect(this.sections.find(findItem('type', 'BREAKING')).components.length).to.equals(1);
+                    expect(this.sections.find(findItem('type', 'BREAKING')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+                });
+
+                it('should chore section to have 3 commit', function () {
+                    expect(this.sections.find(findItem('type', 'chore')).components.find(findItem('name', '$scope')).commits.length).to.equal(3);
+                });
+
+            });
+
         });
 
-        it('should return 4 sections', function() {
-          expect(this.sections.length).to.equal(4);
+        describe('.getPreviousTag()', function () {
+
+            before(function () {
+                changelog.setDefaults();
+            });
+
+            afterEach(function () {
+                if (child.exec.restore) {
+                    child.exec.restore();
+                }
+            });
+
+            it('should succeed when tag option is specified', function () {
+                changelog.options.tag = 'tag';
+                return expect(changelog.getPreviousTag())
+                    .to.eventually.become('tag');
+            });
+
+            it('should succeed when tag option is false', function () {
+                changelog.options.tag = false;
+                return expect(changelog.getPreviousTag())
+                    .to.eventually.become(false);
+            });
+
+            it('should call "git describe --tags" when no tag options', function () {
+                changelog.options.tag = null;
+
+                // simulate return tag
+                sinon.stub(child, 'exec', function (cmd, callback) {
+                    callback(null, 'tag');
+                });
+                return expect(changelog.getPreviousTag())
+                    .to.eventually.become('tag');
+            });
+
+            it('should fail when "git describe" returns a code', function () {
+                changelog.options.tag = null;
+
+                // simulate failure
+                sinon.stub(child, 'exec', function (cmd, callback) {
+                    callback(-1);
+                });
+                return expect(changelog.getPreviousTag())
+                    .to.eventually.be.rejected;
+            });
+
         });
 
-        it('should fix section to have 1 commit', function() {
-          expect(this.sections.find(findItem('type', 'fix')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+        describe('.getRepoUrl()', function () {
+
+            before(function () {
+                changelog.setDefaults();
+                this.repo = 'https://github.com/owner/repo';
+            });
+
+            afterEach(function () {
+                if (child.exec.restore) {
+                    child.exec.restore();
+                }
+            });
+
+            it('should succeed when repo_url option is specified', function () {
+                changelog.options.repo_url = this.repo;
+                return expect(changelog.getRepoUrl())
+                    .to.eventually.become(this.repo);
+            });
+
+            it('should call "git describe --tags" when no tag options', function () {
+                changelog.options.repo_url = null;
+
+                // simulate return tag
+                sinon.stub(child, 'exec', function (cmd, callback) {
+                    callback(null, this.repo);
+                }.bind(this));
+                return expect(changelog.getRepoUrl())
+                    .to.eventually.become(this.repo);
+            });
+
+            it('should fail when "git describe" returns a code', function () {
+                changelog.options.repo_url = null;
+
+                // simulate failure
+                sinon.stub(child, 'exec', function (cmd, callback) {
+                    callback(-1);
+                });
+                return expect(changelog.getRepoUrl())
+                    .to.eventually.be.rejected;
+            });
+
         });
 
-        it('should feat section to have 1 commit', function() {
-          expect(this.sections.find(findItem('type', 'feat')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
+        xdescribe('.generate()', function () {
+
         });
 
-        it('should breaks have 1 component and 2 comits', function() {
-          expect(this.sections.find(findItem('type', 'BREAKING')).components.length).to.equals(1);
-          expect(this.sections.find(findItem('type', 'BREAKING')).components.find(findItem('name', '$scope')).commits.length).to.equal(1);
-        });
+        describe('.log()', function () {
 
-        it('should chore section to have 3 commit', function() {
-          expect(this.sections.find(findItem('type', 'chore')).components.find(findItem('name', '$scope')).commits.length).to.equal(3);
-        });
+            beforeEach(function () {
+                sinon.stub(console, 'log');
+            });
 
-      });
+            it('should call console.log() when debug option is true', function () {
+                changelog.options.debug = true;
+
+                changelog.log('test');
+                expect(console.log).to.have.been.calledOnce;
+
+                expect(console.log).to.have.been.calledWithMatch('test');
+                console.log.restore();
+            });
+
+            xit('should call console.log() when debug option is true', function () {
+                changelog.options.debug = false;
+
+                changelog.log('test');
+                expect(console.log).to.not.have.been.called;
+                console.log.restore();
+            });
+
+        });
 
     });
 
-    describe('.getPreviousTag()', function() {
-
-      before(function() {
-        changelog.setDefaults();
-      });
-
-      afterEach(function() {
-        if (child.exec.restore) {
-          child.exec.restore();
-        }
-      });
-
-      it('should succeed when tag option is specified', function() {
-        changelog.options.tag = 'tag';
-        return expect(changelog.getPreviousTag())
-          .to.eventually.become('tag');
-      });
-
-      it('should succeed when tag option is false', function() {
-        changelog.options.tag = false;
-        return expect(changelog.getPreviousTag())
-          .to.eventually.become(false);
-      });
-
-      it('should call "git describe --tags" when no tag options', function() {
-        changelog.options.tag = null;
-
-        // simulate return tag
-        sinon.stub(child, 'exec', function(cmd, callback) {
-          callback(null, 'tag');
+    describe('File creation', function () {
+        it('should create A CHANGELOG.md', function () {
+            var exists_file = fs.existsSync('CHANGELOG.md');
+            expect(exists_file).to.equal(true);
         });
-        return expect(changelog.getPreviousTag())
-          .to.eventually.become('tag');
-      });
 
-      it('should fail when "git describe" returns a code', function() {
-        changelog.options.tag = null;
-
-        // simulate failure
-        sinon.stub(child, 'exec', function(cmd, callback) {
-          callback(-1);
+        it('should create tag1.md', function () {
+            var exists_file = fs.existsSync('output/tag1.md');
+            expect(exists_file).to.equal(true);
         });
-        return expect(changelog.getPreviousTag())
-          .to.eventually.be.rejected;
-      });
 
-    });
-
-    describe('.getRepoUrl()', function() {
-
-      before(function() {
-        changelog.setDefaults();
-        this.repo = 'https://github.com/owner/repo';
-      });
-
-      afterEach(function() {
-        if (child.exec.restore) {
-          child.exec.restore();
-        }
-      });
-
-      it('should succeed when repo_url option is specified', function() {
-        changelog.options.repo_url = this.repo;
-        return expect(changelog.getRepoUrl())
-          .to.eventually.become(this.repo);
-      });
-
-      it('should call "git describe --tags" when no tag options', function() {
-        changelog.options.repo_url = null;
-
-        // simulate return tag
-        sinon.stub(child, 'exec', function(cmd, callback) {
-          callback(null, this.repo);
-        }.bind(this));
-        return expect(changelog.getRepoUrl())
-          .to.eventually.become(this.repo);
-      });
-
-      it('should fail when "git describe" returns a code', function() {
-        changelog.options.repo_url = null;
-
-        // simulate failure
-        sinon.stub(child, 'exec', function(cmd, callback) {
-          callback(-1);
-        });
-        return expect(changelog.getRepoUrl())
-          .to.eventually.be.rejected;
-      });
-
-    });
-
-    xdescribe('.generate()', function () {
-
-    });
-
-    describe('.log()', function() {
-
-      beforeEach(function() {
-        sinon.stub(console, 'log');
-      });
-
-      it('should call console.log() when debug option is true', function () {
-        changelog.options.debug = true;
-
-        changelog.log('test');
-        expect(console.log).to.have.been.calledOnce;
-
-        expect(console.log).to.have.been.calledWithMatch('test');
-        console.log.restore();
-      });
-
-      xit('should call console.log() when debug option is true', function () {
-        changelog.options.debug = false;
-
-        changelog.log('test');
-        expect(console.log).to.not.have.been.called;
-        console.log.restore();
-      });
-
-    });
-
-  });
-
-  describe('File creation', function(){
-    it('should create A CHANGELOG.md', function(){
-      var  exists_file = fs.existsSync('CHANGELOG.md');
-      expect(exists_file).to.equal(true);
-    });
-
-    it('should create tag1.md', function(){
-      var  exists_file = fs.existsSync('output/tag1.md');
-      expect(exists_file).to.equal(true);
-    });
-
-    it('should create A EXTENDEDCHANGELOG.md', function(){
-      var  exists_file = fs.existsSync('EXTENDEDCHANGELOG.md');
-      expect(exists_file).to.equal(true);
-    });
-  });
-
-  describe('Params tests', function() {
-    it('should read log since beggining if tag is false', function(done) {
-
-      var options = {
-        tag : false
-      };
-
-      changelog.generate(options)
-        .then(function(opts){
-          expect(opts.msg).to.be.a('string');
-          expect(opts.msg.indexOf('since beggining')).to.not.equal(-1);
-          done();
-        })
-        .catch(function(err){
-          console.log('error', err);
-          done(err);
+        it('should create A EXTENDEDCHANGELOG.md', function () {
+            var exists_file = fs.existsSync('EXTENDEDCHANGELOG.md');
+            expect(exists_file).to.equal(true);
         });
     });
 
-    it('should read log since specified tag if tag is present', function(done) {
+    describe('Params tests', function () {
+        it('should read log since beggining if tag is false', function (done) {
 
-      var options = {
-        tag : 'v0.0.1'
-      };
+            var options = {
+                tag: false
+            };
 
-      changelog.generate(options)
-        .then(function(opts){
-          expect(opts.msg).to.be.a('string');
-          expect(opts.msg.indexOf('tag: v0.0.1')).to.not.equal(-1);
-          done();
-        })
-        .catch(function(err){
-          console.log('error', err);
-          done(err);
+            changelog.generate(options)
+                .then(function (opts) {
+                    expect(opts.msg).to.be.a('string');
+                    expect(opts.msg.indexOf('since beggining')).to.not.equal(-1);
+                    done();
+                })
+                .catch(function (err) {
+                    console.log('error', err);
+                    done(err);
+                });
         });
-    });
 
-    it('should add the application name', function(done) {
+        it('should read log since specified tag if tag is present', function (done) {
 
-      var options = {
-        app_name : 'my name'
-      };
+            var options = {
+                tag: 'v0.0.1'
+            };
 
-      changelog.generate(options)
-        .then(function(opts){
-          expect(opts.msg).to.be.a('string');
-          expect(opts.msg.indexOf('name: my name')).to.not.equal(-1);
-          done();
-        })
-        .catch(function(err){
-          console.log('error', err);
-          done(err);
+            changelog.generate(options)
+                .then(function (opts) {
+                    expect(opts.msg).to.be.a('string');
+                    expect(opts.msg.indexOf('tag: v0.0.1')).to.not.equal(-1);
+                    done();
+                })
+                .catch(function (err) {
+                    console.log('error', err);
+                    done(err);
+                });
         });
-    });
 
-  });
+        it('should add the application name', function (done) {
+
+            var options = {
+                app_name: 'my name'
+            };
+
+            changelog.generate(options)
+                .then(function (opts) {
+                    expect(opts.msg).to.be.a('string');
+                    expect(opts.msg.indexOf('name: my name')).to.not.equal(-1);
+                    done();
+                })
+                .catch(function (err) {
+                    console.log('error', err);
+                    done(err);
+                });
+        });
+
+    });
 
 });


### PR DESCRIPTION
I use a private gitlab integration, therefore my URL does not match the regexp. I need to set the provider "manually" in the options.