### PR TITLE
Add possibility to override issue URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-# my name
+<img width="300px" src="https://github.com/rafinskipg/git-changelog/raw/master/images/git-changelog-logo.png" />
+
+# Git changelog
+
+_Git changelog is a utility tool for generating changelogs. It is free and opensource. :)_
+
+
+
+## Features
+
+  - **providers**
+    - possiblity to override issue URL when using an external issue tracker
+  ([d831bb1a](https://github.com/Treyone/git-changelog/commit/d831bb1a1e05fae8dd5f932e1f3b1ffef0c4f456))
+
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,4 @@
-<img width="300px" src="https://github.com/rafinskipg/git-changelog/raw/master/images/git-changelog-logo.png" />
-
-# Git changelog
-
-_Git changelog is a utility tool for generating changelogs. It is free and opensource. :)_
-
-
-
-## Features
-
-  - **providers**
-    - Add possibility to set providers in the options
-  ([14da6fee](https://github.com/rafinskipg/git-changelog/commit/14da6fee8aa8b1fcec198ea26812aa1871008438))
-
+# my name
 
 
 

--- a/EXTENDEDCHANGELOG.md
+++ b/EXTENDEDCHANGELOG.md
@@ -63,6 +63,10 @@ _Git changelog is a utility tool for generating changelogs. It is free and opens
     - Restores versionName in CLI
   ([1d97f952](https://github.com/rafinskipg/git-changelog/commit/1d97f952bd5d37f67c1febdf161f4ce9b310eebf))
 
+  - **provider**
+    - Added provider option in the command
+  ([8f3b3fef](https://github.com/rafinskipg/git-changelog/commit/8f3b3fef0d123e4fd11ea79bb9552285befc6689))
+
   - **template**
     - Fixes missing space in version_name output in template
   ([f494f4a9](https://github.com/rafinskipg/git-changelog/commit/f494f4a93a3c4a245f706cfb65f735a5ccccb2ce),
@@ -108,6 +112,8 @@ _Git changelog is a utility tool for generating changelogs. It is free and opens
   ([86eae3f0](https://github.com/rafinskipg/git-changelog/commit/86eae3f013ace1c5c23afc32b2e8f878a69629f1))
 
   - **providers**
+    - possiblity to override issue URL when using an external issue tracker
+  ([d831bb1a](https://github.com/rafinskipg/git-changelog/commit/d831bb1a1e05fae8dd5f932e1f3b1ffef0c4f456))
     - Add possibility to set providers in the options
   ([14da6fee](https://github.com/rafinskipg/git-changelog/commit/14da6fee8aa8b1fcec198ea26812aa1871008438))
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This specification is used to grep the commits on your log, it contains a valid 
 
 * **branch** : The name of the branch. Defaults to ` `
 * **repo_url** : The url of the project. For issues and commits links. Defaults to `git config --get remote.origin.url`
+* **issue_url** : Optional field, can be used to override the default provider URL, if using an external bug tracker.
 * **provider** : Optional field, the provider is calculated from the repo_url, but can also be passed as config parameter. Values available: gitlab, github, bitbucket.
 * **version_name**: The version name of the project.
 * **file**: The name of the file that will be generated. Defaults to `CHANGELOG.md`,

--- a/output/customTemplate.md
+++ b/output/customTemplate.md
@@ -4,7 +4,7 @@
 
 _This changelog is generated with a custom template_
 
-## squeezy potatoe v0.0.1 ( Wed Jan 18 2017 13:36:19 GMT+0100 (CET) )
+## squeezy potatoe v0.0.1 ( Thu Mar 02 2017 16:18:32 GMT+0100 (CET) )
 
 
 ## Bug Fixes
@@ -20,21 +20,23 @@ _This changelog is generated with a custom template_
   - **generate**
     - create path to file if it does not already exist (62f6210f6895bcf5f9984b26948178b1a93cbc9e)
   - **git log**
-    - Ignores letter case (d4cff0a86c5ce46405f3c0dd03f9c49a7d620792, Closes: [#54](https://github.com/rafinskipg/git-changelog/issues/54))
+    - Ignores letter case (d4cff0a86c5ce46405f3c0dd03f9c49a7d620792, Closes: [#54](https://github.com/Treyone/git-changelog/issues/54))
   - **git tag**
     - get latest tag, regardless of branch for workflows that rely on git-flow releases (48800306fa5ac19b7e9a4c6d7f2f432ee8ae4d84)
   - **git_changelog_generate**
-    - pass tag if it exists to gitReadLog (7c801927672792fc9a818653b74c78d77c7bff9e, Closes: [#5](https://github.com/rafinskipg/git-changelog/issues/5))
+    - pass tag if it exists to gitReadLog (7c801927672792fc9a818653b74c78d77c7bff9e, Closes: [#5](https://github.com/Treyone/git-changelog/issues/5))
   - **nested lists**
-    - nested list fix. Closes #9 (2285551810919bd4d8a749ae3ddd88f9cedcdd0e, Closes: [#9](https://github.com/rafinskipg/git-changelog/issues/9))
+    - nested list fix. Closes #9 (2285551810919bd4d8a749ae3ddd88f9cedcdd0e, Closes: [#9](https://github.com/Treyone/git-changelog/issues/9))
   - **options**
     - Use version_name instead of version (43fdac855bfd2f67a43acc93ecc8ef2e7a81f45c)    - use repo_url instead of url (346b39491923a49a3421f174a566b204d5fc7db9)
   - **package.json**
     - move q to dependancies since it is required to run (257119cf2bb6d8f341a5d65a2f47bcf803dff205)
   - **params**
     - Restores versionName in CLI (1d97f952bd5d37f67c1febdf161f4ce9b310eebf)
+  - **provider**
+    - Added provider option in the command (8f3b3fef0d123e4fd11ea79bb9552285befc6689)
   - **template**
-    - Fixes missing space in version_name output in template (f494f4a93a3c4a245f706cfb65f735a5ccccb2ce, Closes: [#72](https://github.com/rafinskipg/git-changelog/issues/72))
+    - Fixes missing space in version_name output in template (f494f4a93a3c4a245f706cfb65f735a5ccccb2ce, Closes: [#72](https://github.com/Treyone/git-changelog/issues/72))
   - **travis**
     - Removed 0.12 nodejs version, addd 7.3.0 (1819083690e70e0af28d0c155b6fa67cbeb1dfb3)
 
@@ -56,7 +58,7 @@ _This changelog is generated with a custom template_
   - **package**
     - Added global install so you can run via command (86eae3f013ace1c5c23afc32b2e8f878a69629f1)
   - **providers**
-    - Add possibility to set providers in the options (14da6fee8aa8b1fcec198ea26812aa1871008438)
+    - possiblity to override issue URL when using an external issue tracker (d831bb1a1e05fae8dd5f932e1f3b1ffef0c4f456)    - Add possibility to set providers in the options (14da6fee8aa8b1fcec198ea26812aa1871008438)
   - **template**
     - Load default template if no custom template is found (41d5128b922efe3ced883a37bb4e170410160f4f)
 
@@ -69,7 +71,7 @@ _This changelog is generated with a custom template_
   - added documentation for explaining the commit message (d516c2fb464072fc1f4c86ec71a910eeab3e830c
   - Added docs (e0ba50c0bb0b13e9b39a59b8f4dda96e86d55644
   - **readme**
-    - Updated readme (2d7b17625b9783532ee9ba655651cf8d475aa4ce)    - Unuseful commit (4373f4726eedad6d450c8255f5e57036a3e5e223)    - fix link to the `.changelogrc` section (2975171d89e1823253399bbe87a184e9164e9799)    - Follow proper style in example commits (6fef01ba8a71bb5cd779ddb84f52b8f75296618d)    - Reorder contents (14e8a772c3a05c32bc9fba6f75565132025d4942)    - TOC (d6338ab45f6e45e5562e5e6f4f1db86f39ca458d)    - Added more information on the new specification (f984eedde6be5db804d0b6bf2e238ab2e7ca15fb)    - added more commit examples and npm versioning usage (51341b7aae082c6c1a1caaa77dfdbfdc2622a56f)    - add logo (1af36c9b0dad5cc0c2a321e3f280a89d76a8fb2b)    - Final readme Fixes #1 Closes #1 (e725d8f4bf477b517ca6185a75fdfa0aa660b3be, Closes: [#1](https://github.com/rafinskipg/git-changelog/issues/1))
+    - Updated readme (2d7b17625b9783532ee9ba655651cf8d475aa4ce)    - Unuseful commit (4373f4726eedad6d450c8255f5e57036a3e5e223)    - fix link to the `.changelogrc` section (2975171d89e1823253399bbe87a184e9164e9799)    - Follow proper style in example commits (6fef01ba8a71bb5cd779ddb84f52b8f75296618d)    - Reorder contents (14e8a772c3a05c32bc9fba6f75565132025d4942)    - TOC (d6338ab45f6e45e5562e5e6f4f1db86f39ca458d)    - Added more information on the new specification (f984eedde6be5db804d0b6bf2e238ab2e7ca15fb)    - added more commit examples and npm versioning usage (51341b7aae082c6c1a1caaa77dfdbfdc2622a56f)    - add logo (1af36c9b0dad5cc0c2a321e3f280a89d76a8fb2b)    - Final readme Fixes #1 Closes #1 (e725d8f4bf477b517ca6185a75fdfa0aa660b3be, Closes: [#1](https://github.com/Treyone/git-changelog/issues/1))
 
 
 

--- a/output/tag1.md
+++ b/output/tag1.md
@@ -4,119 +4,123 @@
 
 _This changelog is from the previous tag_
 
-## squeezy potatoe v0.0.1 ( Wed Jan 18 2017 13:36:19 GMT+0100 (CET) )
+## squeezy potatoe v0.0.1 ( Thu Mar 02 2017 16:18:32 GMT+0100 (CET) )
 
 
 ## Bug Fixes
   - fix error messages
-  ([ee5068bf](https://github.com/rafinskipg/git-changelog/commit/ee5068bffdbb9c0e45c8ce9ce0c2f790440f19e3))
+  ([ee5068bf](https://github.com/Treyone/git-changelog/commit/ee5068bffdbb9c0e45c8ce9ce0c2f790440f19e3))
   - Fix generation of logs
-  ([cddb2408](https://github.com/rafinskipg/git-changelog/commit/cddb2408fa3017be704acac51dabbba9f477a547))
+  ([cddb2408](https://github.com/Treyone/git-changelog/commit/cddb2408fa3017be704acac51dabbba9f477a547))
   - correctly get branch name from the command line
-  ([4baa075b](https://github.com/rafinskipg/git-changelog/commit/4baa075bd93f878ee708817f911fe89c102dec02))
+  ([4baa075b](https://github.com/Treyone/git-changelog/commit/4baa075bd93f878ee708817f911fe89c102dec02))
   - correctly detect when running under grunt on Windows
-  ([4205ea49](https://github.com/rafinskipg/git-changelog/commit/4205ea49a893e4d1807a39268739c13754d40cf2))
+  ([4205ea49](https://github.com/Treyone/git-changelog/commit/4205ea49a893e4d1807a39268739c13754d40cf2))
   - fixed tests
-  ([2e60172a](https://github.com/rafinskipg/git-changelog/commit/2e60172a4666c70d27e66d15dad297b89fff9583))
+  ([2e60172a](https://github.com/Treyone/git-changelog/commit/2e60172a4666c70d27e66d15dad297b89fff9583))
   - Stream didn't close properly
-  ([99f228cf](https://github.com/rafinskipg/git-changelog/commit/99f228cfa5cb26c46ef9e3b00171a5e3d38fd844))
+  ([99f228cf](https://github.com/Treyone/git-changelog/commit/99f228cfa5cb26c46ef9e3b00171a5e3d38fd844))
   - Github commit url
-  ([c186f2d8](https://github.com/rafinskipg/git-changelog/commit/c186f2d877e7907305953610bcaaef331406178a))
+  ([c186f2d8](https://github.com/Treyone/git-changelog/commit/c186f2d877e7907305953610bcaaef331406178a))
 
   - **checkpath**
     - add missing require('path')
-  ([e5dab826](https://github.com/rafinskipg/git-changelog/commit/e5dab826062bd22dd37c8c3d3c24a4d9b4701f6d))
+  ([e5dab826](https://github.com/Treyone/git-changelog/commit/e5dab826062bd22dd37c8c3d3c24a4d9b4701f6d))
 
   - **generate**
     - create path to file if it does not already exist
-  ([62f6210f](https://github.com/rafinskipg/git-changelog/commit/62f6210f6895bcf5f9984b26948178b1a93cbc9e))
+  ([62f6210f](https://github.com/Treyone/git-changelog/commit/62f6210f6895bcf5f9984b26948178b1a93cbc9e))
 
   - **git log**
     - Ignores letter case
-  ([d4cff0a8](https://github.com/rafinskipg/git-changelog/commit/d4cff0a86c5ce46405f3c0dd03f9c49a7d620792),
-   [#54](https://github.com/rafinskipg/git-changelog/issues/54))
+  ([d4cff0a8](https://github.com/Treyone/git-changelog/commit/d4cff0a86c5ce46405f3c0dd03f9c49a7d620792),
+   [#54](https://github.com/Treyone/git-changelog/issues/54))
 
   - **git tag**
     - get latest tag, regardless of branch for workflows that rely on git-flow releases
-  ([48800306](https://github.com/rafinskipg/git-changelog/commit/48800306fa5ac19b7e9a4c6d7f2f432ee8ae4d84))
+  ([48800306](https://github.com/Treyone/git-changelog/commit/48800306fa5ac19b7e9a4c6d7f2f432ee8ae4d84))
 
   - **git_changelog_generate**
     - pass tag if it exists to gitReadLog
-  ([7c801927](https://github.com/rafinskipg/git-changelog/commit/7c801927672792fc9a818653b74c78d77c7bff9e),
-   [#5](https://github.com/rafinskipg/git-changelog/issues/5))
+  ([7c801927](https://github.com/Treyone/git-changelog/commit/7c801927672792fc9a818653b74c78d77c7bff9e),
+   [#5](https://github.com/Treyone/git-changelog/issues/5))
 
   - **nested lists**
     - nested list fix. Closes #9
-  ([22855518](https://github.com/rafinskipg/git-changelog/commit/2285551810919bd4d8a749ae3ddd88f9cedcdd0e),
-   [#9](https://github.com/rafinskipg/git-changelog/issues/9))
+  ([22855518](https://github.com/Treyone/git-changelog/commit/2285551810919bd4d8a749ae3ddd88f9cedcdd0e),
+   [#9](https://github.com/Treyone/git-changelog/issues/9))
 
   - **options**
     - Use version_name instead of version
-  ([43fdac85](https://github.com/rafinskipg/git-changelog/commit/43fdac855bfd2f67a43acc93ecc8ef2e7a81f45c))
+  ([43fdac85](https://github.com/Treyone/git-changelog/commit/43fdac855bfd2f67a43acc93ecc8ef2e7a81f45c))
     - use repo_url instead of url
-  ([346b3949](https://github.com/rafinskipg/git-changelog/commit/346b39491923a49a3421f174a566b204d5fc7db9))
+  ([346b3949](https://github.com/Treyone/git-changelog/commit/346b39491923a49a3421f174a566b204d5fc7db9))
 
   - **package.json**
     - move q to dependancies since it is required to run
-  ([257119cf](https://github.com/rafinskipg/git-changelog/commit/257119cf2bb6d8f341a5d65a2f47bcf803dff205))
+  ([257119cf](https://github.com/Treyone/git-changelog/commit/257119cf2bb6d8f341a5d65a2f47bcf803dff205))
 
   - **params**
     - Restores versionName in CLI
-  ([1d97f952](https://github.com/rafinskipg/git-changelog/commit/1d97f952bd5d37f67c1febdf161f4ce9b310eebf))
+  ([1d97f952](https://github.com/Treyone/git-changelog/commit/1d97f952bd5d37f67c1febdf161f4ce9b310eebf))
+
+  - **provider**
+    - Added provider option in the command
+  ([8f3b3fef](https://github.com/Treyone/git-changelog/commit/8f3b3fef0d123e4fd11ea79bb9552285befc6689))
 
   - **template**
     - Fixes missing space in version_name output in template
-  ([f494f4a9](https://github.com/rafinskipg/git-changelog/commit/f494f4a93a3c4a245f706cfb65f735a5ccccb2ce),
-   [#72](https://github.com/rafinskipg/git-changelog/issues/72))
+  ([f494f4a9](https://github.com/Treyone/git-changelog/commit/f494f4a93a3c4a245f706cfb65f735a5ccccb2ce),
+   [#72](https://github.com/Treyone/git-changelog/issues/72))
 
   - **travis**
     - Removed 0.12 nodejs version, addd 7.3.0
-  ([18190836](https://github.com/rafinskipg/git-changelog/commit/1819083690e70e0af28d0c155b6fa67cbeb1dfb3))
+  ([18190836](https://github.com/Treyone/git-changelog/commit/1819083690e70e0af28d0c155b6fa67cbeb1dfb3))
 
 
 
 
 ## Pull requests merged
   - Merge pull request #74 from Treyone/master
-  ([4d539ace](https://github.com/rafinskipg/git-changelog/commit/4d539ace7ff22a9be468270114109f2565203aa4))
+  ([4d539ace](https://github.com/Treyone/git-changelog/commit/4d539ace7ff22a9be468270114109f2565203aa4))
   - Merge pull request #73 from fabn/gitlab-links
-  ([6df54f09](https://github.com/rafinskipg/git-changelog/commit/6df54f09ab62175b89a853d3695e8d43bfedac95))
+  ([6df54f09](https://github.com/Treyone/git-changelog/commit/6df54f09ab62175b89a853d3695e8d43bfedac95))
   - Merge pull request #70 from rafinskipg/templating
-  ([5e60232c](https://github.com/rafinskipg/git-changelog/commit/5e60232cf92b66cf50f64f3a7734de98fe2637e7))
+  ([5e60232c](https://github.com/Treyone/git-changelog/commit/5e60232cf92b66cf50f64f3a7734de98fe2637e7))
   - Merge pull request #60 from seivan/feature/latest_tag_regardless_of_branch
-  ([1ff50d0d](https://github.com/rafinskipg/git-changelog/commit/1ff50d0dc03f8c0db9961c034945c3ef8f4268f7))
+  ([1ff50d0d](https://github.com/Treyone/git-changelog/commit/1ff50d0dc03f8c0db9961c034945c3ef8f4268f7))
   - Merge pull request #58 from olamothe/master
-  ([3fed7270](https://github.com/rafinskipg/git-changelog/commit/3fed727077168815f24aad7bbf5768913e3843ab))
+  ([3fed7270](https://github.com/Treyone/git-changelog/commit/3fed727077168815f24aad7bbf5768913e3843ab))
   - Merge pull request #55 from kerimdzhanov/patch-1
-  ([31d13896](https://github.com/rafinskipg/git-changelog/commit/31d1389637b59ac3a6c68c3f8fca99045675c36c))
+  ([31d13896](https://github.com/Treyone/git-changelog/commit/31d1389637b59ac3a6c68c3f8fca99045675c36c))
   - Merge pull request #50 from rafinskipg/changelogrc
-  ([fd07a4bf](https://github.com/rafinskipg/git-changelog/commit/fd07a4bf039c7c8ddbb496c644dfd5fcc1627904))
+  ([fd07a4bf](https://github.com/Treyone/git-changelog/commit/fd07a4bf039c7c8ddbb496c644dfd5fcc1627904))
   - Merge pull request #41 from pmiossec/fix_branch_option
-  ([6247118a](https://github.com/rafinskipg/git-changelog/commit/6247118a573259cbe71c6fdd28cb53dcb7f1b855))
+  ([6247118a](https://github.com/Treyone/git-changelog/commit/6247118a573259cbe71c6fdd28cb53dcb7f1b855))
   - Merge pull request #45 from xcambar/versionName
-  ([2e50373a](https://github.com/rafinskipg/git-changelog/commit/2e50373a6f42e53598612f0e474c008624d6e80c))
+  ([2e50373a](https://github.com/Treyone/git-changelog/commit/2e50373a6f42e53598612f0e474c008624d6e80c))
   - Merge pull request #47 from Sjors/patch-1
-  ([d786fd08](https://github.com/rafinskipg/git-changelog/commit/d786fd084d7c1c250c866bec3c5d0c73b9abe271))
+  ([d786fd08](https://github.com/Treyone/git-changelog/commit/d786fd084d7c1c250c866bec3c5d0c73b9abe271))
   - Merge pull request #46 from zoner14/master
-  ([0485a1fd](https://github.com/rafinskipg/git-changelog/commit/0485a1fd4bf01662f50b93098c6b535eb7c527eb))
+  ([0485a1fd](https://github.com/Treyone/git-changelog/commit/0485a1fd4bf01662f50b93098c6b535eb7c527eb))
   - Merge pull request #37 from richardthombs/fix-grunt-on-windows
-  ([5f024339](https://github.com/rafinskipg/git-changelog/commit/5f02433963b5b603c5763bd5c1a37cf8ca9e3598))
+  ([5f024339](https://github.com/Treyone/git-changelog/commit/5f02433963b5b603c5763bd5c1a37cf8ca9e3598))
   - Merge pull request #33 from richardthombs/fix-typos
-  ([2656d150](https://github.com/rafinskipg/git-changelog/commit/2656d150eb95c6ad9326e4265ba64edf8e49a11c))
+  ([2656d150](https://github.com/Treyone/git-changelog/commit/2656d150eb95c6ad9326e4265ba64edf8e49a11c))
   - Merge pull request #30 from JohnnyEstilles/refactor/get-stream
-  ([a52b1169](https://github.com/rafinskipg/git-changelog/commit/a52b1169a2510d83d6d4fd5113ce157f30c4d4d0))
+  ([a52b1169](https://github.com/Treyone/git-changelog/commit/a52b1169a2510d83d6d4fd5113ce157f30c4d4d0))
   - Merge pull request #25 from JohnnyEstilles/code-climate
-  ([28053b92](https://github.com/rafinskipg/git-changelog/commit/28053b9292d3d61fb33a004f6088c244e653b76b))
+  ([28053b92](https://github.com/Treyone/git-changelog/commit/28053b9292d3d61fb33a004f6088c244e653b76b))
   - Merge pull request #23 from JohnnyEstilles/docs/readme-updates
-  ([3079151a](https://github.com/rafinskipg/git-changelog/commit/3079151a8d5f90d0830aab4437a65dff4d837b2a))
+  ([3079151a](https://github.com/Treyone/git-changelog/commit/3079151a8d5f90d0830aab4437a65dff4d837b2a))
   - Merge pull request #20 from JohnnyEstilles/feature/code-refactoring
-  ([be209f04](https://github.com/rafinskipg/git-changelog/commit/be209f04c22f1ce2cb82e6412c4ddf117897a9e7))
+  ([be209f04](https://github.com/Treyone/git-changelog/commit/be209f04c22f1ce2cb82e6412c4ddf117897a9e7))
   - Merge pull request #12 from jodybrewster/master
-  ([219ea809](https://github.com/rafinskipg/git-changelog/commit/219ea8091ac81a55b0210c9a7fd41a7f0ee5660f))
+  ([219ea809](https://github.com/Treyone/git-changelog/commit/219ea8091ac81a55b0210c9a7fd41a7f0ee5660f))
   - Merge pull request #7 from colegleason/fix-tags
-  ([1d4f6043](https://github.com/rafinskipg/git-changelog/commit/1d4f604363094d4eee3b4d7b1ca01133edaad344))
+  ([1d4f6043](https://github.com/Treyone/git-changelog/commit/1d4f604363094d4eee3b4d7b1ca01133edaad344))
   - Merge pull request #6 from colegleason/add-q
-  ([2a712b9c](https://github.com/rafinskipg/git-changelog/commit/2a712b9cfd912f36b6f7f70d16b336575881881a))
+  ([2a712b9c](https://github.com/Treyone/git-changelog/commit/2a712b9cfd912f36b6f7f70d16b336575881881a))
 
 
 

--- a/tasks/lib/get-provider-links.js
+++ b/tasks/lib/get-provider-links.js
@@ -8,15 +8,15 @@ function getProviderLinks() {
     // Also brings the posibility of adding more providers
     var providerLinks = {
         github: {
-            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            issue: '[#%s](%issue_url%/issues/%s)',
             commit: '[%s](' + this.options.repo_url + '/commit/%s)'
         },
         bitbucket: {
-            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            issue: '[#%s](%issue_url%/issues/%s)',
             commit: '[%s](' + this.options.repo_url + '/commits/%s)'
         },
         gitlab: {
-            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            issue: '[#%s](%issue_url%/issues/%s)',
             commit: '[%s](' + this.options.repo_url + '/commit/%s)'
         }
     };
@@ -35,6 +35,8 @@ function getProviderLinks() {
         }
     }
     this.links = providerLinks[this.provider];
+    this.links.issue = this.links.issue.replace('%issue_url%', this.options.issue_url || this.options.repo_url)
+
 }
 
 module.exports = getProviderLinks;

--- a/test/git_changelog_generate.spec.js
+++ b/test/git_changelog_generate.spec.js
@@ -155,6 +155,19 @@ describe('git_changelog_generate.js', function () {
                 expect(changelog.provider).to.equal('gitlab');
 
             });
+
+
+            it('should take the issue url passed in the options in priority', function () {
+                changelog.options.issue_url = 'http://toto.toto.com';
+
+                changelog.options.provider = 'gitlab';
+                changelog.getProviderLinks();
+                expect(changelog.links.issue).to.equal('[#%s](http://toto.toto.com/issues/%s)');
+
+            });
+
+
+
             it('should ignore unknown providers', function () {
                 var repo_url = 'https://github.com/owner/repo';
                 changelog.options.repo_url = repo_url;


### PR DESCRIPTION
When using an external issue tracker, like Redmine, issue URL must be overriden to point to the right issues.