### PR TITLE
feat(providers): possiblity to set external tracker issue URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ This specification is used to grep the commits on your log, it contains a valid 
 * **branch** : The name of the branch. Defaults to ` `
 * **repo_url** : The url of the project. For issues and commits links. Defaults to `git config --get remote.origin.url`
 * **provider** : Optional field, the provider is calculated from the repo_url, but can also be passed as config parameter. Values available: gitlab, github, bitbucket.
+* **issue_url** : Optional field, can be used to override the default provider URL, if using an external bug tracker.
 * **version_name**: The version name of the project.
 * **file**: The name of the file that will be generated. Defaults to `CHANGELOG.md`,
 * **template**: The template for generating the changelog. It defaults to the one inside this project (/templates/template.md)

--- a/tasks/lib/get-provider-links.js
+++ b/tasks/lib/get-provider-links.js
@@ -8,15 +8,15 @@ function getProviderLinks() {
     // Also brings the posibility of adding more providers
     var providerLinks = {
         github: {
-            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            issue: '[#%s](%issue_url%/issues/%s)',
             commit: '[%s](' + this.options.repo_url + '/commit/%s)'
         },
         bitbucket: {
-            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            issue: '[#%s](%issue_url%/issues/%s)',
             commit: '[%s](' + this.options.repo_url + '/commits/%s)'
         },
         gitlab: {
-            issue: '[#%s](' + this.options.repo_url + '/issues/%s)',
+            issue: '[#%s](%issue_url%/issues/%s)',
             commit: '[%s](' + this.options.repo_url + '/commit/%s)'
         }
     };
@@ -35,6 +35,8 @@ function getProviderLinks() {
         }
     }
     this.links = providerLinks[this.provider];
+    this.links.issue = this.links.issue.replace('%issue_url%', this.options.issue_url || this.options.repo_url);
+
 }
 
 module.exports = getProviderLinks;

--- a/test/git_changelog_generate.spec.js
+++ b/test/git_changelog_generate.spec.js
@@ -155,6 +155,16 @@ describe('git_changelog_generate.js', function () {
                 expect(changelog.provider).to.equal('gitlab');
 
             });
+
+            it('should take the issue url passed in the options in priority', function () {
+                changelog.options.issue_url = 'http://toto.toto.com';
+
+                changelog.options.provider = 'gitlab';
+                changelog.getProviderLinks();
+                expect(changelog.links.issue).to.equal('[#%s](http://toto.toto.com/issues/%s)');
+
+            });
+
             it('should ignore unknown providers', function () {
                 var repo_url = 'https://github.com/owner/repo';
                 changelog.options.repo_url = repo_url;


### PR DESCRIPTION
As discussed, I kept only required changes.